### PR TITLE
Add channelResponseCallback to onJoinChannel action.

### DIFF
--- a/src/actions/channels/actions.js
+++ b/src/actions/channels/actions.js
@@ -61,19 +61,23 @@ export function leavePhoenixChannelEvent({ channelTopic, event }) {
  * @param {string?} params.domainUrl - url for socket to connect to, by default will use PHOENIX_SOCKET_DOMAIN storage key
  * @param {string} params.channelTopic - Name of channel/Topic
  * @param {String?} params.token - token for channel
- * @param {Boolean?} params.logPresence - determines if you presence should be tracked for the channel
+ * @param {Boolean?} params.logPresence - determines if your presence should be tracked for the channel
  */
 export function getPhoenixChannel({
   logPresence = false,
   channelTopic,
+  channelResponseEvent = null,
+  channelErrorResponseEvent = null,
   events = [],
-  token = null,
-  domainUrl = null,
+  token = '',
+  domainUrl = '',
 }) {
   return {
     type: PHOENIX_GET_CHANNEL,
     data: {
       channelTopic,
+      channelResponseEvent,
+      channelErrorResponseEvent,
       logPresence,
       channelToken: token,
       domainUrl,

--- a/src/middlewares/phoenix/actions/index.js
+++ b/src/middlewares/phoenix/actions/index.js
@@ -175,6 +175,8 @@ export function connectPhoenixChannelPresence({ channel, dispatch }) {
 export function connectToPhoenixChannelForEvents({
   dispatch,
   channelTopic,
+  channelResponseEvent,
+  channelErrorResponseEvent,
   logPresence,
   events,
   token = null,
@@ -200,6 +202,7 @@ export function connectToPhoenixChannelForEvents({
           })
         );
         dispatch(endPhoenixChannelProgress({ channelTopic, loadingStatusKey: channelTopic }));
+        dispatch(channelResponseEvent({data: response, channelTopic, channel}))
       })
       .receive(channelStatuses.CHANNEL_ERROR, (response) => {
         if (response && response.reason === 'unauthorized') {
@@ -207,6 +210,7 @@ export function connectToPhoenixChannelForEvents({
         }
         dispatch(phoenixChannelJoinError({ error: response, channelTopic, channel }));
         dispatch(endPhoenixChannelProgress({ channelTopic, loadingStatusKey: channelTopic }));
+        dispatch(channelErrorResponseEvent({error: response, channelTopic, channel}))
       })
       .receive(channelStatuses.CHANNEL_TIMEOUT, (response) => {
         dispatch(

--- a/src/middlewares/phoenix/phoenixChannelMiddleware.js
+++ b/src/middlewares/phoenix/phoenixChannelMiddleware.js
@@ -202,7 +202,7 @@ export const createPhoenixChannelMiddleware = () => (store) => (next) => (action
       const socketDetails = selectPhoenixSocketDetails(currentState);
       const phoenixDomain = selectPhoenixSocketDomain(currentState);
       const socketDomain = socket ? socket.endPoint : '';
-      const { channelTopic, domainUrl, events, channelToken, logPresence } = action.data;
+      const { channelTopic, channelResponseEvent, channelErrorResponseEvent, domainUrl, events, channelToken, logPresence } = action.data;
 
       const domain = formatSocketDomain({ domainString: domainUrl || phoenixDomain });
       const loggedInDomain = `${domain}/websocket`;
@@ -231,6 +231,8 @@ export const createPhoenixChannelMiddleware = () => (store) => (next) => (action
         connectToPhoenixChannelForEvents({
           dispatch,
           channelTopic,
+          channelResponseEvent,
+          channelErrorResponseEvent,
           events,
           logPresence,
           token: channelToken,


### PR DESCRIPTION
* we need to have a possibilities to track onChannelJoin responses (according to backend architectures)
* also we need to have an opportunity to trigger some action in case of onChannelJoin failed (for example to show error)

According to existing implementation we only get default JOIN_FAILED response, which is very complex to differentiate from other  onChannelJoin events (we could have plenty of them in the same time)

