### PR TITLE
Remove reference to module in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ lib
 
 # TernJS port file
 .tern-port
+
+.idea/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   },
   "description": "Middleware for react-redux to map Redux Actions and Phoenix Channel Message Events",
   "main": "dist/@trixtateam/phoenix-to-redux.cjs.js",
-  "module": "dist/@trixtateam/phoenix-to-redux.esm.js",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
As the module no longer exists this is confusing IDEs when looking for the module for code completion.